### PR TITLE
build: juno config as js

### DIFF
--- a/juno.config.js
+++ b/juno.config.js
@@ -1,0 +1,9 @@
+import {defineConfig} from '@junobuild/config';
+
+/** @type {import('@junobuild/config').JunoConfig} */
+export default defineConfig({
+  satellite: {
+    id: 'svftd-daaaa-aaaal-adr3a-cai',
+    source: 'build'
+  }
+});

--- a/juno.json
+++ b/juno.json
@@ -1,6 +1,0 @@
-{
-  "satellite": {
-    "satelliteId": "svftd-daaaa-aaaal-adr3a-cai",
-    "source": "build"
-  }
-}

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -254,6 +254,12 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
     },
+    "node_modules/@junobuild/config": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@junobuild/config/-/config-0.0.5.tgz",
+      "integrity": "sha512-UJaeKgvyYuwi9NfqR+PCE+ynQkVD7ZLpMix5+2G03XWKYznuqDbCefH+wO1rE4arrc6wvu4tPG5SV0twhrmKog==",
+      "dev": true
+    },
     "node_modules/@junobuild/core": {
       "version": "0.0.46",
       "resolved": "https://registry.npmjs.org/@junobuild/core/-/core-0.0.46.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "openai": "^4.24.7"
       },
       "devDependencies": {
+        "@junobuild/config": "^0.0.5",
         "@rollup/plugin-inject": "^5.0.3",
         "@sveltejs/adapter-static": "^2.0.3",
         "@sveltejs/kit": "^1.20.4",
@@ -619,6 +620,12 @@
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "node_modules/@junobuild/config": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@junobuild/config/-/config-0.0.5.tgz",
+      "integrity": "sha512-UJaeKgvyYuwi9NfqR+PCE+ynQkVD7ZLpMix5+2G03XWKYznuqDbCefH+wO1rE4arrc6wvu4tPG5SV0twhrmKog==",
       "dev": true
     },
     "node_modules/@junobuild/core": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json --watch"
   },
   "devDependencies": {
+    "@junobuild/config": "^0.0.5",
     "@rollup/plugin-inject": "^5.0.3",
     "@sveltejs/adapter-static": "^2.0.3",
     "@sveltejs/kit": "^1.20.4",


### PR DESCRIPTION
`juno.json` is still supported but, TypeScript or JavaScript are now the recommanded way to configure Juno.
In addition this PR also add a dev dependency to provide intelisense to the editor.

PS: This is not related to your issue, just a goodie.